### PR TITLE
Stable V1.47.2 release

### DIFF
--- a/scripts/lastest/v1/PlayerGui/PlayScreen/LivePlayProcessing.luau
+++ b/scripts/lastest/v1/PlayerGui/PlayScreen/LivePlayProcessing.luau
@@ -4,6 +4,7 @@ local modData = require(workspace.ModData)
 local DifficultyCalculator = require(workspace.DifficultyCalculator)
 local PerformanceCalculator = require(workspace.PerformanceCalculator)
 local StrainSkills = require(workspace.DifficultyCalculator.StrainSkills)
+local ConverterTools = require(workspace.OsuConvert.converterTools)
 export type PSValue = {Aim:number, Speed:number, Rhythm:number, Flashlight:number, AimStrainDecay:number, SpeedStrainDecay:number, FLStrainDecay:number}
 export type LivePlayProcessing = {
 	new:() -> (LivePlayProcessing),
@@ -135,8 +136,8 @@ end
 
 function LivePlayProcessing:SetupData(Attributes:InputAttributes)
 	self.ModData = Attributes.ModData
-	self.ODRate = Attributes.ODRate
-	self.ARRate = Attributes.ARRate
+	self.ODRate = ConverterTools.GetDifficultyValueAfterMod.OD(Attributes.ODRate, Attributes.ModData)
+	self.ARRate = ConverterTools.GetDifficultyValueAfterMod.OD(Attributes.ARRate, Attributes.ModData)
 	self.NoteCount = Attributes.NoteCount
 	self.AimDiffStrainCount = Attributes.AimDiffStrainCount
 	self.SpeedDiffStrainCount = Attributes.SpeedDiffStrainCount

--- a/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
+++ b/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
@@ -621,6 +621,30 @@ function GetModData(Mod,Detailed)
 			ReturnText = ReturnText.."EZ"
 		end
 	end
+	
+	if Mod.SA and Mod.SA ~= 1 then
+		ModUsed = true
+		if Mods > 0 then
+			ReturnText = ReturnText..","
+		end
+		Mods += 1
+		local _format = string.format("SA(%.1fx)", Mod.SA)
+		local _formatDetailed = string.format("SpeedAdjust(%.1fx)", Mod.SA)
+		
+		if Mod.SA == 1.5 then
+			_format = "DT"
+			_formatDetailed = "DoubleTime"
+		elseif Mod.SA == 0.75 then
+			_format = "HT"	
+			_formatDetailed = "HalfTime"	
+		end
+		
+		if Detailed then
+			ReturnText = ReturnText.._formatDetailed
+		else
+			ReturnText = ReturnText.._format
+		end
+	end
 
 	if Mod.SL == true then
 		ModUsed = true
@@ -649,7 +673,7 @@ function GetModData(Mod,Detailed)
 	end
 
 	if Mods > 0 and not Detailed then
-		ReturnText = ReturnText.." | "
+		ReturnText = ReturnText
 	elseif Mods == 0 and Detailed then
 		ReturnText = "None"
 	end
@@ -745,6 +769,8 @@ function ShowLeaderboardPlayDetail(Data)
 	if Data.Mod == nil then -- old plays
 		Data.Mod = {} -- just replace it with no value instead
 	end
+	
+	Data.Mod.SA = Data.Speed or 1
 
 	local ModDetail = GetModData(Data.Mod,true)
 	local PlayedDate = os.date("*t",tonumber(Data.Date))
@@ -1127,7 +1153,7 @@ LoadLeaderboard = function()
 	LeaderboardInterface.PersonalBestTitle.TextTransparency = 1
 
 	-- Get map lb data from the server
-	local GolbalData:{UserPlayInfo}, PersonalData:UserPlayInfo, SessionChanged:boolean = game.ReplicatedStorage.BeatmapLeaderboard:InvokeServer(1,{DatastoreName = CurrentKey})
+	local GolbalData:{UserPlayInfo}, PersonalData:UserPlayInfo, SessionChanged:boolean = game.ReplicatedStorage.BeatmapLeaderboard:InvokeServer(1,{DatastoreName = CurrentKey, UsingPerformanceLeaderboard = PSLeaderboard})
 	-- prevent duplicating request
 	if SessionChanged == true or CurrentLeaderboardSession ~= ThisLBSession then return end
 
@@ -1270,9 +1296,10 @@ LoadLeaderboard = function()
 					NewLBFrame.MainFrame.UserName.Text = "@"..Data.Name
 					local MaxComboText = ""
 					if Data.ExtraData ~= nil then
+						Data.ExtraData.Mod.SA = Data.ExtraData.Speed or 1
 						MaxComboText = " ("..tostring(Data.ExtraData.MaxCombo).."x)"
 						NewLBFrame.MainFrame.Accuracy.Text = tostring(Data.ExtraData.Accurancy).."%"
-						NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)..string.format("%.2fx",Data.ExtraData.Speed)
+						NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)
 						NewLBFrame.MainFrame.Grade.Text = Data.ExtraData.Grade
 						if Data.ExtraData.Grade == "SS" then
 							NewLBFrame.MainFrame.Grade.Text = "S"
@@ -1423,9 +1450,10 @@ LoadLeaderboard = function()
 				end)
 				local MaxComboText = ""
 				if Data.ExtraData ~= nil then
+					Data.ExtraData.Mod.SA = Data.ExtraData.Speed or 1
 					MaxComboText = " ("..tostring(Data.ExtraData.MaxCombo).."x)"
 					NewLBFrame.MainFrame.Accuracy.Text = tostring(Data.ExtraData.Accurancy).."%"
-					NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)..string.format("%.2fx",math.floor(Data.ExtraData.Speed*100)/100)
+					NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)
 					NewLBFrame.MainFrame.Grade.Text = Data.ExtraData.Grade
 					if Data.ExtraData.Grade == "SS" then
 						NewLBFrame.MainFrame.Grade.Text = "S"
@@ -8294,7 +8322,13 @@ DisplayModPlayed = (function()
 
 	-- Check for SongSpeed and format if necessary
 	if SongSpeed ~= 1 then
-		table.insert(mods, string.format(",SA(%sx)", tostring(math.round(SongSpeed * 100) / 100)))
+		if SongSpeed == 1.5 then
+			table.insert(mods, "DT")
+		elseif SongSpeed == 0.75 then
+			table.insert(mods, "HT")
+		else
+			table.insert(mods, string.format(",SA(%sx)", tostring(math.round(SongSpeed * 100) / 100)))
+		end
 	end
 	-- Only concatenate if mods exist
 	if #mods > 0 then

--- a/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
+++ b/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
@@ -2588,7 +2588,7 @@ local ModData:modData.ModData = {
 	AT = AutoPlay,
 	SO = false,
 	V2 = ScoreV2Enabled,
-	TD = TouchDeviceDetected or Replay_TouchDevice,
+	TD = not ReplayMode and IsTouchDeviceActive() or Replay_TouchDevice,
 	DA = DifficultyAdjust,
 	SA = SongSpeed
 }

--- a/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
+++ b/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
@@ -646,16 +646,16 @@ function GetModData(Mod,Detailed)
 		end
 	end
 
-	if Mod.SL == true then
+	if Mod.SL == false then
 		ModUsed = true
 		if Mods > 0 then
 			ReturnText = ReturnText..","
 		end
 		Mods += 1
 		if Detailed then
-			ReturnText = ReturnText.."Slider"
+			ReturnText = ReturnText.."NoSliders"
 		else
-			ReturnText = ReturnText.."SL"
+			ReturnText = ReturnText.."NS"
 		end
 	end
 
@@ -671,9 +671,81 @@ function GetModData(Mod,Detailed)
 			ReturnText = ReturnText.."FL"
 		end
 	end
+	
+	if Mod.DA and Mod.DA.Active then
+		ModUsed = true
+		if Mods > 0 then
+			ReturnText = ReturnText..","
+		end
+		Mods += 1
+		local _format = "DA("
+		local _longFormat = "DifficultyAdjust("
+		local function _add(txt, num, addComma)
+			local strNum = tostring(math.floor(num*10)/10)
+			_format..= txt..strNum..(addComma and "," or ")")
+			_longFormat..= txt..strNum..(addComma and "," or ")")
+		end
+		local _data = Mod.DA.Data
+		if _data.CS then
+			_add("CS", _data.CS, true)
+		end
+		if _data.AR then
+			_add("AR", _data.AR, true)
+		end
+		if _data.OD then
+			_add("OD", _data.OD, true)
+		end
+		if _data.HP then
+			_add("HP", _data.HP, false)
+		end
+		if Detailed then
+			ReturnText = ReturnText.._longFormat
+		else
+			ReturnText = ReturnText.._format
+		end
+	end
+	
+	if Mod.RX then
+		ModUsed = true
+		if Mods > 0 then
+			ReturnText = ReturnText..","
+		end
+		Mods += 1
+		if Detailed then
+			ReturnText = ReturnText.."Relax"
+		else
+			ReturnText = ReturnText.."RX"
+		end
+	end
+	
+	if Mod.SO then
+		ModUsed = true
+		if Mods > 0 then
+			ReturnText = ReturnText..","
+		end
+		Mods += 1
+		if Detailed then
+			ReturnText = ReturnText.."SpunOut"
+		else
+			ReturnText = ReturnText.."SO"
+		end
+	end
+	
+	if Mod.AP then
+		ModUsed = true
+		if Mods > 0 then
+			ReturnText = ReturnText..","
+		end
+		Mods += 1
+		if Detailed then
+			ReturnText = ReturnText.."AutoPilot"
+		else
+			ReturnText = ReturnText.."AP"
+		end
+	end
 
 	if Mods > 0 and not Detailed then
-		ReturnText = ReturnText
+		ReturnText = " | "..ReturnText
 	elseif Mods == 0 and Detailed then
 		ReturnText = "None"
 	end
@@ -1299,7 +1371,7 @@ LoadLeaderboard = function()
 						Data.ExtraData.Mod.SA = Data.ExtraData.Speed or 1
 						MaxComboText = " ("..tostring(Data.ExtraData.MaxCombo).."x)"
 						NewLBFrame.MainFrame.Accuracy.Text = tostring(Data.ExtraData.Accurancy).."%"
-						NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)
+						NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date)..GetModData(Data.ExtraData.Mod)
 						NewLBFrame.MainFrame.Grade.Text = Data.ExtraData.Grade
 						if Data.ExtraData.Grade == "SS" then
 							NewLBFrame.MainFrame.Grade.Text = "S"
@@ -1453,7 +1525,7 @@ LoadLeaderboard = function()
 					Data.ExtraData.Mod.SA = Data.ExtraData.Speed or 1
 					MaxComboText = " ("..tostring(Data.ExtraData.MaxCombo).."x)"
 					NewLBFrame.MainFrame.Accuracy.Text = tostring(Data.ExtraData.Accurancy).."%"
-					NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date).." | "..GetModData(Data.ExtraData.Mod)
+					NewLBFrame.MainFrame.PlayDate.Text = GetDate(Data.ExtraData.Date)..GetModData(Data.ExtraData.Mod)
 					NewLBFrame.MainFrame.Grade.Text = Data.ExtraData.Grade
 					if Data.ExtraData.Grade == "SS" then
 						NewLBFrame.MainFrame.Grade.Text = "S"

--- a/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
+++ b/scripts/lastest/v1/PlayerGui/PlayScreen/OsuGame.luau
@@ -4154,10 +4154,6 @@ if CircleApproachTime/SongSpeed < hit50 then
 	script.Parent.HitError.MissArea.Size = UDim2.new(MissTiming/(hit50*2),0,0.25,0)
 end
 
-if SpeedSync then
-	CircleApproachTime /= SongSpeed
-end
-
 script.Parent.HitError.Size = UDim2.new(0,hit50*(19/16)*HitErrorMulti,0,25)
 script.Parent.HitError.HitErrorDisplay._300s.Size = UDim2.new(hit300/hit50,0,0.25,0)
 script.Parent.HitError.HitErrorDisplay._100s.Size = UDim2.new(hit100/hit50,0,0.25,0)


### PR DESCRIPTION
What's changed in V1.47.1 and V1.47.2 (Compare to V1.47):
-> Remove the SpeedAdjust **DoubleEffect** on ApproachTime
-> Fix the bug that the game does not recognize the touch-device mod when playing the game when processing difficulty => The buff was not applied
-> Speed adjust now display in the leaderboard as a mod
-> Display DoubleTime/HalfTime if SA is 1.5 or 0.75
-> Inverse the mod data SL into NS (if SL is not enabled)
-> Add DIfficultyAdjust mod to the display
-> Add future possible mod into leaderboard display
-> Fix the Performance Calculator does not apply mod effect to OD and AR, making an inaccurate result